### PR TITLE
Adding in replace for windows paths

### DIFF
--- a/tasks/ng_template.js
+++ b/tasks/ng_template.js
@@ -61,7 +61,9 @@ module.exports = function (grunt) {
 
                             grunt.log.ok(configs.PATH.resolve(abspath).replace(configs.appDir_path, '').replace(/^\//, ''));
 
-                            var _filename = configs.PATH.resolve(abspath).replace(configs.appDir_path, '').replace(/^\//, ''),
+                            var _filename = configs.PATH.resolve(abspath).replace(configs.appDir_path, '')
+                            		.replace(/\\/g, '/')
+                            		.replace(/^\//, ''),
                                 content = grunt.file.read(configs.PATH.resolve(abspath)),
                                 parsed = configs.TEMPLATE.replace('<% filename %>', _filename).replace('<% content %>', content);
 


### PR DESCRIPTION
When running the ng_template on windows, the windows paths used back slashes '\' instead of forward slashes '/'. Added a replace for the backslashes in the file path that is used when writing the template to the index page. 
